### PR TITLE
OSX 10.8 was called Mountain Lion

### DIFF
--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/html/releasenotes.haml
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/html/releasenotes.haml
@@ -41,7 +41,7 @@
       %h2 Version 1.0.3 by AlterStep
       %time Thu, 18 Jun 2014
       %p
-        Runs on OSX 10.8 (Snow Leopard), 10.9 (Mavericks) and 10.10 (Yosemite)
+        Runs on OSX 10.8 (Mountain Lion), 10.9 (Mavericks) and 10.10 (Yosemite)
       %p
         New set of icons, contributed by Aaron VonderHaar
 

--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/html/releasenotes.html
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/html/releasenotes.html
@@ -49,7 +49,7 @@
       <h2>Version 1.0.3 by AlterStep</h2>
       <time>Thu, 18 Jun 2014</time>
       <p>
-        Runs on OSX 10.8 (Snow Leopard), 10.9 (Mavericks) and 10.10 (Yosemite)
+        Runs on OSX 10.8 (Mountain Lion), 10.9 (Mavericks) and 10.10 (Yosemite)
       </p>
       <p>
         New set of icons, contributed by Aaron VonderHaar

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ The purpose of this application is to allow the user to have a better
 experience controlling the DNSCrypt Proxy on OSX.
 
 [Download dnscrypt-osxclient-1.0.5.dmg](https://github.com/alterstep/dnscrypt-osxclient/releases/download/1.0.5/dnscrypt-osxclient-1.0.5.dmg)
-for OSX 10.8 (Snow Leopard), OSX 10.9 (Mavericks) and OSX 10.10 (Yosemite).
+for OSX 10.8 (Mountain Lion), OSX 10.9 (Mavericks) and OSX 10.10 (Yosemite).
 
 Compatible with:
 * CloudNS


### PR DESCRIPTION
Open DNS runs a forum that has a section about DNSCrypt. And they mentioned that your "fork" incorrectly reports 10.8 as snow leopard when it's really Mountain Lion.