### PR TITLE
de-ns1.de renamed to dnscrypt.me

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ Compatible with:
 * d0wn
 * [iPredator](https://ipredator.se/)
 * okTurtles
-* [de-ns1.de](http://dnscrypt.me/)
+* [dnscrypt.me](http://dnscrypt.me/)
 
 Packages are signed with [Minisign](https://jedisct1.github.io/minisign/) and can be verified with:
 


### PR DESCRIPTION
The resolver has its own domain now. Therefore its name has been adapted.