### PR TITLE
Random dig server instead of hardcoded one

### DIFF
--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/start-dnscrypt-proxy.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/start-dnscrypt-proxy.sh
@@ -43,7 +43,7 @@ try_resolver() {
         logger_debug "Proxy for [$description] is up"
         prefix=($(eval echo "{a..m}"))
         answers=$(exec dig +time=1 +short +tries=2 -p $priority \
-          @"$INTERFACE_PROBES" ${prefix[$[ RANDOM % 12 ]]]}.root-servers.net). 2> /dev/null | \
+          @"$INTERFACE_PROBES" ${prefix[$[ RANDOM % 12 ]]]}.root-servers.net. 2> /dev/null | \
           egrep -ic '^[0-9.:]+$')
         [ -r "$pid_file" ] && kill $(cat -- "$pid_file")
         if [ $answers -gt 0 ]; then

--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/start-dnscrypt-proxy.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/start-dnscrypt-proxy.sh
@@ -41,8 +41,9 @@ try_resolver() {
     case "$line" in
       *Proxying\ from\ *)
         logger_debug "Proxy for [$description] is up"
+        prefix=($(eval echo "{a..m}"))
         answers=$(exec dig +time=1 +short +tries=2 -p $priority \
-          @"$INTERFACE_PROBES" www.apple.com. 2> /dev/null | \
+          @"$INTERFACE_PROBES" ${prefix[$[ RANDOM % 12 ]]]}.root-servers.net). 2> /dev/null | \
           egrep -ic '^[0-9.:]+$')
         [ -r "$pid_file" ] && kill $(cat -- "$pid_file")
         if [ $answers -gt 0 ]; then


### PR DESCRIPTION
Dig command use random root name server [a-m].root-servers.net instead of hardcoded www.apple.com. Not perfect, but better solution.