### PR TITLE
Empty the states directory after a reboot

### DIFF
--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/afterboot.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/afterboot.sh
@@ -7,6 +7,7 @@ rm -f "$QUERY_LOG_FILE"
 rm -f "$DEBUG_LOG_FILE"
 find -x "$RESOLVERS_LIST_STATE" -type f -mtime +1 -exec rm -f {} \; 2>/dev/null
 find -x "$APP_UPDATES_STATE" -type f -mtime +1 -exec rm -f {} \; 2>/dev/null
+find -x "$STATES_DIR" -type f -exec rm -f {} -exec rm -f {} \; 2>/dev/null
 
 ./clear-fw.sh
 


### PR DESCRIPTION
After a shutdown we need to remove the previous checksum file, and maybe removing everything else wouldn't hurt either.

Perhaps the checksum file should also be removed after a network change.