### PR TITLE
use scutil for looking up and modifying OS DNS configuration

### DIFF
--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/get-dhcp-resolvers.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/get-dhcp-resolvers.sh
@@ -2,37 +2,22 @@
 
 . ./common.inc
 
-get_ifs() {
-  ifs_save="$IFS"
-  IFS=''
-  ifconfig -a | while read line; do
-    nif=$(echo "$line" | egrep -i '^[^ 	]+:\s+flags' | sed 's/:.*$//')
-    isact=$(echo "$line" | egrep -i 'status:\s*active')
-    if [ -n "$nif" ]; then
-      cif="$nif"
-    elif [ -n "$isact" -a -n "$cif" ]; then
-      echo $cif
-    fi
-  done
-  IFS="$ifs_save"
+get_primary_service() {
+  scutil <<EOF | awk '$1 == "PrimaryService" { print $3 }'
+show State:/Network/Global/IPv4
+EOF
 }
 
-ifs=$(get_ifs)
+get_ips_bkup() {
+  service="$1"
+  scutil <<EOF | sed -n -e '/ServerAddresses/,/}/ { /[{}]/n; s/.* : \(.*\)$/\1/ p; }'
+get State:/Network/Service/$service/DNS
+get State:/Network/Service/$service/DNS.dnscryptbackup
+d.show
+EOF
+}
 
-typeset -A found
-ips=""
-for i in $ifs; do
-  ips_i=$(ipconfig getpacket "$i" 2> /dev/null | fgrep 'domain_name_server' | \
-          sed -e 's/^.*{//' -e 's/,/ /g' -e 's/}//' )
-  for ip_i in $ips_i; do
-    if [ ! ${found["$ip_i"]} ]; then
-      if [ "$ips" ]; then
-        ips="$ips "
-      fi
-      ips="$ips$ip_i"
-      found["$ip_i"]=1
-    fi
-  done
-done
+service="$(get_primary_service)"
+ips=( $(get_ips_bkup "$service") )
 
-echo "$ips"
+echo "${ips[*]}"

--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/set-dns.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/set-dns.sh
@@ -2,16 +2,33 @@
 
 . ./common.inc
 
-servers="$*"
+get_primary_service() {
+  scutil <<EOF | awk '$1 == "PrimaryService" { print $3 }'
+show State:/Network/Global/IPv4
+EOF
+}
+
+set_ips_active() {
+  service="$1"
+  shift
+  ips="$@"
+  scutil <<EOF
+get State:/Network/Service/$service/DNS
+get State:/Network/Service/$service/DNS.dnscryptbackup
+set State:/Network/Service/$service/DNS.dnscryptbackup
+d.add ServerAddresses * ${ips[*]}
+set State:/Network/Service/$service/DNS
+EOF
+}
+
+servers="$@"
 
 [ $# -lt 1 ] && exit 1
 
 logger_debug "Setting DNS resolvers to [$servers]"
 
-exec networksetup -listallnetworkservices 2>/dev/null | \
-fgrep -v '*' | while read x ; do
-  networksetup -setdnsservers "$x" $servers
-done
+service="$(get_primary_service)"
+set_ips_active "$service" "${servers[@]}"
 
 logger_debug "Flushing local DNS cache"
 

--- a/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/switch-exceptions-on.sh
+++ b/DNSCrypt-Preference-Pane/DNSCrypt/extra/usr/scripts/switch-exceptions-on.sh
@@ -14,7 +14,7 @@ get_gw() {
 }
 
 get_dhcp_dns() {
-  cat "$DHCP_DNS_FILE" 2> /dev/null | egrep -i '^[0-9a-f:.]+$'
+  ./get-dhcp-resolvers.sh
 }
 
 [ -s "$EXCEPTIONS_FILE" ] || exec ./switch-exceptions-off.sh


### PR DESCRIPTION
On my system the DNS configuration was being overridden by an application (a VPN client), which resulted in 2 problems.
1. `networksetup -setdnsservers` effectively did nothing.
2. The exception domains were being sent to the wrong DNS server (were being sent to the DHCP DNS instead of the VPN dns).

This change fixes both. The code looks at whatever DNS configuration is currently the primary, backs it up, and the overwrites it.
In my limited testing, this works for both normal DHCP configuration, as well as application (VPN client) configuration.

This isn't necessarily meant to be merged, but I figured it was the easiest way to demonstrate the issue and how to fix it.